### PR TITLE
Bump commons-beanutils from 1.8.0 to 1.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.4</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>


### PR DESCRIPTION
Bumps commons-beanutils from 1.8.0 to 1.9.4.

Signed-off-by: dependabot[bot] <support@github.com>